### PR TITLE
Add interactive DFW map example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
-# South-Asian
-Interactive Geo-Map
+# South-Asian Interactive Geo-Map
+
+This repository provides a small example of how to build an interactive map of
+the Dallas&ndash;Fort Worth (DFW) area highlighting South Asian community regions
+and centers.
+
+The map is generated using Python and the [Folium](https://python-visualization.github.io/folium/) library. It loads
+basic information about community centers from `data/community_centers.csv` and
+creates an HTML file named `dfw_map.html` with clickable markers and simple
+polygon overlays for areas with large South Asian populations.
+
+## Requirements
+- Python 3.8+
+- `folium` Python package
+
+## Usage
+1. Install dependencies (ideally in a virtual environment):
+   ```bash
+   pip install folium
+   ```
+2. Run the script:
+   ```bash
+   python generate_map.py
+   ```
+   This will create `dfw_map.html` in the project directory.
+3. Open `dfw_map.html` in a web browser to explore the map.
+
+Feel free to extend `data/community_centers.csv` with additional locations or
+adjust the polygons in `generate_map.py` to better fit your data.

--- a/data/community_centers.csv
+++ b/data/community_centers.csv
@@ -1,0 +1,5 @@
+name,description,address,lat,lon
+DFW Hindu Temple,A prominent Hindu temple in the area,1605 N Britain Rd, Irving,32.829,-96.955
+Dallas Islamic Center,A community center serving the Muslim community,10225 State Hwy 121, Frisco,33.109,-96.807
+Gujarati Samaj of DFW,South Asian cultural gathering place,4600 W Airport Fwy, Irving,32.837,-97.013
+Muslim Legal Services,Legal aid for Muslim community,1234 Commerce St, Dallas,32.782,-96.794

--- a/generate_map.py
+++ b/generate_map.py
@@ -1,0 +1,61 @@
+import csv
+import folium
+
+# Center of Dallas-Fort Worth area
+DFW_CENTER = [32.9, -97.0]
+
+
+def add_population_regions(m):
+    """Highlight general regions known for sizable South Asian communities."""
+    regions = {
+        "Irving": [
+            [32.80, -97.03],
+            [32.80, -96.90],
+            [32.95, -96.90],
+            [32.95, -97.03],
+        ],
+        "Frisco": [
+            [33.09, -96.91],
+            [33.09, -96.78],
+            [33.17, -96.78],
+            [33.17, -96.91],
+        ],
+        "Plano": [
+            [33.00, -96.77],
+            [33.00, -96.64],
+            [33.10, -96.64],
+            [33.10, -96.77],
+        ],
+    }
+    for name, coords in regions.items():
+        folium.Polygon(
+            coords,
+            color="blue",
+            weight=2,
+            fill=True,
+            fill_color="blue",
+            fill_opacity=0.15,
+            popup=name,
+        ).add_to(m)
+
+
+def add_community_centers(m, csv_path="data/community_centers.csv"):
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            folium.Marker(
+                [float(row["lat"]), float(row["lon"])],
+                tooltip=row["name"],
+                popup=f"<b>{row['name']}</b><br>{row['description']}<br>{row['address']}",
+            ).add_to(m)
+
+
+def build_map():
+    m = folium.Map(location=DFW_CENTER, zoom_start=10, tiles="CartoDB positron")
+    add_population_regions(m)
+    add_community_centers(m)
+    m.save("dfw_map.html")
+
+
+if __name__ == "__main__":
+    build_map()


### PR DESCRIPTION
## Summary
- add a CSV of example South Asian community centers
- create `generate_map.py` for an interactive map with Folium
- document setup and usage in the README

## Testing
- `python generate_map.py` *(fails: ModuleNotFoundError: No module named 'folium')*

------
https://chatgpt.com/codex/tasks/task_e_68473e88dd6c8333a917e74e27e25b78